### PR TITLE
fix(core): schema validator makes all body fields required

### DIFF
--- a/backend/core/middlewares.js
+++ b/backend/core/middlewares.js
@@ -18,10 +18,7 @@ const errorHandler = () => {
 
 const schemaValidator = (schema) => {
 	return (req, res, next) => {
-		const result = schema.validate(req.body, {
-			presence: "required",
-			abortEarly: false
-		});
+		const result = schema.validate(req.body, { abortEarly: false });
 		if (result.error) {
 			const errors = result.error.details.reduce((acc, error) => {
 				console.log(error);


### PR DESCRIPTION
`{ presence: required }` in `schemaValidator` was intended to ensure that the request body is not `null` However, it makes all request body fields required by default.

Also, no need to ensure that the request body is not `null`, `body-parser` just returns a `{}` when it's not provided a request body. ([source](https://expressjs.com/en/api.html))